### PR TITLE
Added hook for OCP\Share::validatePassword event

### DIFF
--- a/lib/Hooks.php
+++ b/lib/Hooks.php
@@ -83,6 +83,10 @@ class Hooks {
             $this->passValidator->validate($event->getArgument('password'));
         });
 
+        $this->dispatcher->addListener('OCP\Share::validatePassword', function(GenericEvent $event) {
+            $this->passValidator->validate($event->getArgument('password'));
+        });
+
     }
 
     /**

--- a/tests/HooksTest.php
+++ b/tests/HooksTest.php
@@ -87,7 +87,7 @@ class HooksTest extends TestCase {
     public function testRegister() {
         $this->userManagerMock->expects($this->exactly(3))
             ->method('listen');
-        $this->dispatcherMock->expects($this->once())
+        $this->dispatcherMock->expects($this->exactly(2))
             ->method('addListener');
         $this->hooks->register();
     }


### PR DESCRIPTION
Just added a listener for the OCP\Share::validatePassword event so that the password policy applies to shares as well.